### PR TITLE
Add Slack management endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This application receives Google Forms submissions and creates Slack channels au
 3. Run the application:
    ```bash
    uvicorn main:app
-   ```
+```
 
 ## Example Request
 
@@ -24,3 +24,8 @@ Send a POST request to `/forms/webhook` with JSON body:
   "visibility": "public"
 }
 ```
+
+## Additional Endpoints
+
+- `POST /create-channel` - Create a Slack channel directly
+- `GET /debug/token-info` - Debug Slack token information

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,3 @@
+from . import forms, slack
+
+__all__ = ["forms", "slack"]

--- a/app/routers/slack.py
+++ b/app/routers/slack.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, HTTPException
+from app.services.slack_service import create_channel, token_info
+from app.schemas.channel import CreateChannelRequest, CreateChannelResponse, TokenInfoResponse
+import logging
+
+router = APIRouter(tags=["slack"])
+logger = logging.getLogger(__name__)
+
+@router.post("/create-channel", response_model=CreateChannelResponse)
+async def create_channel_endpoint(payload: CreateChannelRequest):
+    """Create a Slack channel directly via API."""
+    is_private = payload.channel_type.lower() == "private"
+    try:
+        channel_id = create_channel(payload.channel_name, is_private)
+        return CreateChannelResponse(channel_name=payload.channel_name, channel_id=channel_id)
+    except Exception as e:
+        logger.error("Channel creation failed: %s", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/debug/token-info", response_model=TokenInfoResponse)
+async def debug_token_info():
+    """Return basic information about the configured Slack token."""
+    try:
+        info = token_info()
+        return info
+    except Exception as e:
+        logger.error("Token info retrieval failed: %s", e)
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app/schemas/channel.py
+++ b/app/schemas/channel.py
@@ -19,3 +19,21 @@ class ChannelRequestResponse(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class CreateChannelRequest(BaseModel):
+    channel_name: str
+    channel_type: Literal['Public', 'Private']
+    who_for: Optional[str] = None
+    submitted_by: Optional[str] = None
+
+
+class CreateChannelResponse(BaseModel):
+    channel_name: str
+    channel_id: str
+
+
+class TokenInfoResponse(BaseModel):
+    user_id: str
+    team: Optional[str] = None
+    url: Optional[str] = None

--- a/app/services/slack_service.py
+++ b/app/services/slack_service.py
@@ -30,3 +30,16 @@ def invite_users(channel: str, user_ids: list[str]):
         client.conversations_invite(channel=channel, users=','.join(user_ids))
     except SlackApiError as e:
         raise RuntimeError(f"Slack API error: {e.response['error']}")
+
+
+def token_info() -> dict:
+    """Return basic information about the Slack token using auth.test."""
+    try:
+        resp = client.auth_test()
+        return {
+            "user_id": resp.get("user_id"),
+            "team": resp.get("team"),
+            "url": resp.get("url"),
+        }
+    except SlackApiError as e:
+        raise RuntimeError(f"Slack API error: {e.response['error']}")

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from app.database import Base, engine
 import logging
 
 logging.basicConfig(level=logging.INFO)
-from app.routers import forms
+from app.routers import forms, slack
 
 app = FastAPI()
 
@@ -12,6 +12,7 @@ async def startup_event():
     Base.metadata.create_all(bind=engine)
 
 app.include_router(forms.router)
+app.include_router(slack.router)
 
 @app.get("/health")
 async def health():


### PR DESCRIPTION
## Summary
- add `/create-channel` and `/debug/token-info` APIs
- wire new Slack router in `main.py`
- provide Pydantic schemas for the new endpoints
- implement Slack service helper `token_info`
- update README with available endpoints

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851857986048320be5aa20ab1567e85